### PR TITLE
Add docker setup for development

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ruby:2.3.4
+
+RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+
+# Fixes a rails-specific issue, see https://docs.docker.com/compose/rails/
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+
+# Switch to non-privileged user
+RUN mkdir -p /var/www && chown www-data /var/www
+USER www-data
+
+WORKDIR /app
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+# RUN bundle config --global frozen 1
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+RUN figaro install
+
+COPY . .
+
+EXPOSE 3000
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,15 +47,4 @@ ActiveRecord::Schema.define(version: 20181116224603) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "admins", force: :cascade do |t|
-
-    t.string   "email"
-
-  end
-  
-  create_table "frizbees", force: :cascade do |t|
-    t.string   "name"
-    t.string   "email"
-
-  end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.1"
+services:
+  rails:
+    build: .
+    volumes:
+      - ".:/app"
+    ports:
+      - "3000:3000"
+    env_file:
+      - ../aws-secrets.env

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /app/tmp/pids/server.pid
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"


### PR DESCRIPTION
This is just for development if anyone else doesn't want to use cloud9.

When I ran the migrations, it removed some dead tables from the schema.

# Testing
- Install docker on your machine
- Create an `aws-secrets.env` file in the parent directory of the project.
- Run `docker-compose up` from the project root.