### PR TITLE
Fix test cases resulted from renaming search tab to directory

### DIFF
--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -16,10 +16,10 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
   
-  test "should redirect to search after delete" do 
+  test "should redirect to directory after delete" do 
     login_as(@user)
     @profile1.destroy
-    get search_url
+    get directory_url
     assert_response :success
   end
    
@@ -32,7 +32,7 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
   test "should redirect to search after update" do 
     login_as(@user)
     @profile1.update({first_name: "Bob"})
-    get search_url
+    get directory_url
     assert_response :success
   end
   

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -8,8 +8,8 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     sign_in(@user)
   end
 
-  test "should get search" do
-    get search_url
+  test "should get directory" do
+    get directory_url
     assert_response :success
   end
 end

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -25,8 +25,8 @@ class StaticPagesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "should get search" do
-    get :search
+  test "should get directory" do
+    get :directory
     assert_response :success
   end
   


### PR DESCRIPTION
Resolved all 4 errors involving the missing search tab, fix for #161 

Run `rails t` or `rails test` to see all passing test cases.   