### PR TITLE
Allow upgrading user to admin

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,7 @@ class UsersController < ApplicationController
 
     def user_params
       params.require(:user).permit(:id, :name, :email, :password,
-                                   :password_confirmation)
+                                   :password_confirmation, :admin)
     end
   
 end

--- a/app/views/users/edit_info.html.erb
+++ b/app/views/users/edit_info.html.erb
@@ -12,6 +12,9 @@
       <%= f.label :email %>
       <%= f.email_field :email, class: 'form-control' %>
       <br>
+      <%= f.label :admin, class: "col control-label"%>
+      <%= f.check_box :admin, {}, "admin" %>
+      <br>
       <%= f.submit "Save changes", class: "btn btn-primary" %>
     <% end %>
   </div>


### PR DESCRIPTION
Resolves #192 

# Changes

- Admins can now upgrade a user account to admin account in Edit User Info page. Admin can do the reverse for other admin accounts if they uncheck the admin checkbox in Edit User Info. 

# Testing

1. Go to Edit User Info
2. Check/Uncheck the admin checkbox
3. See if the account is upgraded to admin (or the reverse) :">
4. Cool!
