### PR TITLE
Fix profiles page layout on IE 8

### DIFF
--- a/app/assets/stylesheets/profiles.scss
+++ b/app/assets/stylesheets/profiles.scss
@@ -67,14 +67,15 @@
 }
 
 .profile {
+  display: inline-block;
+  vertical-align: top;
+
   @media screen {
     width: 250px;
     margin: 5px;
   }
 
   @media print {
-    display: inline-block;
-    vertical-align: top;
     width: calc(25% - 1em);
     margin: 5px 0;
   }


### PR DESCRIPTION
# Changes

- No change for normal browsers
- Directory page now looks decent on IE8

# Testing

1. Start the server
2. In a normal browser, to to the directory page and make sure it still looks the same
3. Start a VM with IE8
4. Navigate to the directory page in IE8 and make the profile pictures show up in rows