### PR TITLE
Show nicknames in directory view

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,7 +13,7 @@ class ProfilesController < ApplicationController
 
     bucket = get_bucket
     @results = all_results.map do |profile|
-      if profile.nickname
+      if profile.nickname.present?
         name = "#{profile.last_name}, #{profile.nickname} (#{profile.first_name})"
       else
         name = "#{profile.last_name}, #{profile.first_name}"

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,8 +13,14 @@ class ProfilesController < ApplicationController
 
     bucket = get_bucket
     @results = all_results.map do |profile|
+      if profile.nickname
+        name = "#{profile.last_name}, #{profile.nickname} (#{profile.first_name})"
+      else
+        name = "#{profile.last_name}, #{profile.first_name}"
+      end
+
       {
-        :name => profile.last_name + ", " + profile.first_name,
+        :name => name,
         :image_url => profile_image(profile, bucket),
         :link => profile_path(profile.id)
       }

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,4 +1,4 @@
-# require 'test_helper'
+require 'test_helper'
 
 class ProfilesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
@@ -22,7 +22,7 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     get profiles_path
     assert_response :success
     assert_select ".profile" do |profile_elements|
-      assert_select profile_elements[0], ".profile__name", "Green, Frog"
+      assert_select profile_elements[0], ".profile__name", "Green, Froggy (Frog)"
       assert_select profile_elements[1], ".profile__name", "No'Info, Sparse"
     end
   end


### PR DESCRIPTION
Resolves #200 

# Changes

- Directory page now shows nicknames if they exist

# Testing

1. Run `rails test`
2. Start the server
3. Go to the directory page.  Profiles that have no nickname should display as they did.  Profiles with nicknames should show full names in parenthesis