### PR TITLE
Fix formatting of bio

### DIFF
--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,5 +1,5 @@
 module ProfilesHelper
   def normalize_line_breaks(text)
-    text.gsub(/\r\n/, "\n").gsub(/\n+/, "\n\n")
+    text.strip.gsub(/\s*\n\s*/, "\n").gsub(/\n+/, "\n\n")
   end
 end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,2 +1,5 @@
 module ProfilesHelper
+  def normalize_line_breaks(text)
+    text.gsub(/\r\n/, "\n").gsub(/\n+/, "\n\n")
+  end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -82,7 +82,7 @@
         <% if @profile.biography.present? %>
           <b>Biography:</b>
             <div id="bio", style="font-size:25px; white-space: pre-line; text-align:justify">
-              <%= @profile.biography %>
+              <%= normalize_line_breaks @profile.biography %>
             </div>
         <% end %>
 

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,4 +1,4 @@
-# require 'test_helper'
+require 'test_helper'
 
 class ProfilesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
@@ -25,6 +25,13 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
       assert_select profile_elements[0], ".profile__name", "Green, Frog"
       assert_select profile_elements[1], ".profile__name", "No'Info, Sparse"
     end
+  end
+
+  test "should normalize biography line breaks" do
+    login_as(users(:normal))
+    get profile_path(profiles(:frog))
+
+    assert_select "#bio", "One\n\ntwo\n\nthree\n\nfour"
   end
 
   test "should get new" do

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -10,6 +10,7 @@ frog:
   spouse: Baddie User
   cell: 1112224324
   landline: 9871232324
+  biography: "One\ntwo\n\n\nthree\n\nfour"
 
 sparse:
   first_name: Sparse

--- a/test/helpers/profiles_helper_test.rb
+++ b/test/helpers/profiles_helper_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class ProfilesHelperTest < ActionView::TestCase
+  test "normalize_line_breaks should change all repeated line breaks to 2 breaks" do
+    assert_equal(
+      normalize_line_breaks("foo\n\n\n\nbar\nbaz\n\nzing"),
+      "foo\n\nbar\n\nbaz\n\nzing"
+    )
+  end
+
+  test "normalize_line_breaks changes CRLF line breaks to LF" do
+    assert_equal(
+      normalize_line_breaks("foo\r\n\r\n\r\nbar\r\nbaz\r\n\r\nzing"),
+      "foo\n\nbar\n\nbaz\n\nzing"
+    )
+  end
+
+  test "normalize_line_breaks should do nothing when there are no line breaks" do
+    assert_equal(normalize_line_breaks("foo bar baz zing"), "foo bar baz zing")
+    assert_equal(normalize_line_breaks(""), "")
+  end
+end

--- a/test/helpers/profiles_helper_test.rb
+++ b/test/helpers/profiles_helper_test.rb
@@ -15,6 +15,20 @@ class ProfilesHelperTest < ActionView::TestCase
     )
   end
 
+  test "normalize_line_breaks removes whitespace around line breaks" do
+    assert_equal(
+      normalize_line_breaks("foo  \n   \n\t\nbar\n baz\t\n\t\n\tzing"),
+      "foo\n\nbar\n\nbaz\n\nzing"
+    )
+  end
+
+  test "normalize_line_breaks removes whitespace around the text" do
+    assert_equal(
+      normalize_line_breaks(" \n  \tfoo \n\n\n"),
+      "foo"
+    )
+  end
+
   test "normalize_line_breaks should do nothing when there are no line breaks" do
     assert_equal(normalize_line_breaks("foo bar baz zing"), "foo bar baz zing")
     assert_equal(normalize_line_breaks(""), "")


### PR DESCRIPTION
Resolves #201 

# Changes

- Any number of line breaks in a bio is displayed as only two.

# Testing

1. Run `rails test`
2. Start the server
3. Go to a profile page.  Edit the bio to use single line breaks between paragraphs or multiple line breaks between paragraphs.
4. Save it.
5. The bio should display all paragraphs as if they only have two line breaks between them.